### PR TITLE
Tags section, .gitignore, config update, see descirption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 
 # Nette
 /app/config/config.local.neon
-/log
-/temp
 
 # Assets
 /www/assets/css/*.css

--- a/app/config/config.local.sample
+++ b/app/config/config.local.sample
@@ -6,6 +6,7 @@ parameters:
 		dbname: <fill me>
 		user: <fill me>
 		password: <fill me>
+		port: 3306
 
 	# Error mail
 	#system:

--- a/app/config/ext/nextras.neon
+++ b/app/config/ext/nextras.neon
@@ -10,6 +10,7 @@ dbal:
 	username: %database.user%
 	password: %database.password%
 	connectionTz: '+2:00'
+	port: %database.port%
 
 orm:
 	model: App\Model\Database\ORM\EntityModel

--- a/app/modules/Front.Portal/Addon/Controls/AddonDetail/templates/header.latte
+++ b/app/modules/Front.Portal/Addon/Controls/AddonDetail/templates/header.latte
@@ -19,10 +19,6 @@
                 {$addon->name}
             </a>
         </li>
-        <li class="title-tags">
-            <span n:foreach="$addon->tags as $tag" class="label label-success"><a href="{plink Index:tag tag => $tag->name}">#{$tag->name}</a></span>
-
-        </li>
     </ul>
 </div>
 

--- a/app/modules/Front.Portal/Addon/Controls/AddonDetail/templates/sidebar.latte
+++ b/app/modules/Front.Portal/Addon/Controls/AddonDetail/templates/sidebar.latte
@@ -70,6 +70,15 @@
     </ul>
 </div>
 
+<div class="requirements tags">
+    <div class="title">Tags</div>
+    <span n:foreach="$addon->tags as $tag" class="label label-success">
+        <a href="{plink Index:tag tag => $tag->name}">
+            <i class="octicon octicon-tag"></i> {$tag->name}
+        </a>
+    </span>
+</div>
+
 {if $addon->isComposer && $addon->github->masterComposer}
     {var $composer => $addon->github->masterComposer}
     {if ($require = $composer->get('require', []))}
@@ -90,7 +99,7 @@
         <div class="requirements">
             <div class="title">Keywords</div>
             <a n:foreach="$keywords as $name" data-ga="1" data-event="click" data-category="keywords" data-action="{$name}" href="{$addon->composer->linker->getTagUrl($name)}">
-                <span class="label label-default"><i class="octicon octicon-tag"></i> {$name}</span>
+                <span class="label label-default">{$name}</span>
             </a>
         </div>
     {/if}

--- a/log/.gitignore
+++ b/log/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/temp/.gitignore
+++ b/temp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/www/assets/front/css/theme.less
+++ b/www/assets/front/css/theme.less
@@ -560,18 +560,6 @@ q:after {
         }
       }
 
-      .title-tags {
-        margin-left: 15px;
-        span {
-          vertical-align: middle;
-          font-size: 12px;
-          a {
-            display: inline;
-            color: white;
-          }
-        }
-      }
-
       ul {
         margin: 0;
         padding: 0;
@@ -763,10 +751,9 @@ q:after {
       }
     }
 
-    .tags {
-      span {
-        font-size: 80%;
-        font-weight: normal;
+    .requirements.tags {
+      span.label {
+        padding: .3em .6em;
         a {
           color: #fff;
         }


### PR DESCRIPTION
- Tags section moved to sidebar above the keywords section
- Empty (!) /log + /temp directory added to git (ready for UNIX like systems)
- Added ability to specify database port in config.local.neon