### PR TITLE
fixes #104

### DIFF
--- a/app/model/Database/Helpers/GithubLinker.php
+++ b/app/model/Database/Helpers/GithubLinker.php
@@ -147,7 +147,7 @@ final class GithubLinker
 	 */
 	public function getBlobUrl($uri, $branch = 'master')
 	{
-		return $this->repo . '/blob/' . $branch . ' /' . $uri;
+		return $this->repo . '/blob/' . $branch . '/' . $uri;
 	}
 
 	/**


### PR DESCRIPTION
The fix removes redundant space character inside `getBlobUrl`-generated URLs, fixes #104